### PR TITLE
Fix autoupdate

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -37,11 +37,13 @@ ram.runtime = "50M"
     default = "visitors"
 
 [resources]
-    [resources.sources.main]
-    url = "https://github.com/klaussilveira/gitlist/releases/download/2.0.0/gitlist-2.0.0.zip"
-    sha256 = "06df38598c7e6f8ceb62e09efc0849960dc8f8e4a8a6f4719624c82e5a21fdf7"
-    in_subdir = false
-    autoupdate.strategy = "latest_github_release"
+
+    [resources.sources]
+        [resources.sources.main]
+        url = "https://github.com/klaussilveira/gitlist/releases/download/2.0.0/gitlist-2.0.0.zip"
+        sha256 = "06df38598c7e6f8ceb62e09efc0849960dc8f8e4a8a6f4719624c82e5a21fdf7"
+        in_subdir = false
+        autoupdate.strategy = "latest_github_release"
 
     [resources.system_user]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -37,11 +37,11 @@ ram.runtime = "50M"
     default = "visitors"
 
 [resources]
-        [resources.sources.main]
-        url = "https://github.com/klaussilveira/gitlist/releases/download/2.0.0/gitlist-2.0.0.zip"
-        sha256 = "06df38598c7e6f8ceb62e09efc0849960dc8f8e4a8a6f4719624c82e5a21fdf7"
-        in_subdir = false
-        autoupdate.strategy = "latest_github_releases"
+    [resources.sources.main]
+    url = "https://github.com/klaussilveira/gitlist/releases/download/2.0.0/gitlist-2.0.0.zip"
+    sha256 = "06df38598c7e6f8ceb62e09efc0849960dc8f8e4a8a6f4719624c82e5a21fdf7"
+    in_subdir = false
+    autoupdate.strategy = "latest_github_release"
 
     [resources.system_user]
 


### PR DESCRIPTION
Autoupdate currently fails as `autoupdate.strategy = "latest_github_releases"` instead of `autoupdate.strategy = "latest_github_release"` (without 's' at the end). See https://paste.yunohost.org/raw/obuximumef . 

```
Traceback (most recent call last):
  File "/var/www/app_yunohost/apps/tools/autoupdate_app_sources/autoupdate_app_sources.py", line 637, in run_autoupdate_for_multiprocessing
    result = AppAutoUpdater(app).run(edit=edit, commit=commit, pr=pr)
  File "/var/www/app_yunohost/apps/tools/autoupdate_app_sources/autoupdate_app_sources.py", line 233, in run
    update = self.get_source_update(source, infos)
  File "/var/www/app_yunohost/apps/tools/autoupdate_app_sources/autoupdate_app_sources.py", line 383, in get_source_update
    raise ValueError(
ValueError: Unknown update strategy 'latest_github_releases' for 'main', expected one of ['latest_github_release', 'latest_github_tag', 'latest_github_commit', 'latest_gitlab_release', 'latest_gitlab_tag', 'latest_gitlab_commit', 'latest_gitea_release', 'latest_gitea_tag', 'latest_gitea_commit', 'latest_forgejo_release', 'latest_forgejo_tag', 'latest_forgejo_commit']
```

This PR fixes the autoupdate error.